### PR TITLE
fix(deps): adapt naming to match phlex 1.10+

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
 
 DEPENDENCIES
   minitest (~> 5.0)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ class Hello < Phlex::HTML
     @name = name
   end
 
-  def template
+  def view_template
     div do
       render Phlex::Heroicons::HandRaised.new(variant: :solid, classes: 'h-4 w-4')
       h1 { "Hello #{@name}!" }

--- a/lib/phlex/heroicons/base.rb
+++ b/lib/phlex/heroicons/base.rb
@@ -11,7 +11,7 @@ module Phlex
         @classes = classes
       end
 
-      def template
+      def view_template
         send(variant) if respond_to?(variant)
       end
     end


### PR DESCRIPTION
This takes care of the following deprecation warning.

> ⚠️ [DEPRECATION] Defining the `template` method on a Phlex component will not be supported in Phlex 2.0. Please rename `Phlex::Heroicons::Base#template` to `Phlex::Heroicons::Base#view_template` instead.